### PR TITLE
Remove LD_RUNPATH_SEARCH_PATHS for macOS target

### DIFF
--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -2472,7 +2472,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Framework/Lumberjack/CocoaLumberjack-Prefix.pch";
 				INFOPLIST_FILE = "Framework/Lumberjack/CocoaLumberjack-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Framework/Lumberjack/CocoaLumberjack.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.cocoalumberjack.macos;
 				PRODUCT_NAME = CocoaLumberjack;
@@ -2498,7 +2497,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Framework/Lumberjack/CocoaLumberjack-Prefix.pch";
 				INFOPLIST_FILE = "Framework/Lumberjack/CocoaLumberjack-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Framework/Lumberjack/CocoaLumberjack.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.cocoalumberjack.macos;
 				PRODUCT_NAME = CocoaLumberjack;


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

When you run `qlmanage -p /Applications/Xcode.app`
You get:
```
/Applications/Xcode.app
dyld: warning, LC_RPATH @executable_path/../Frameworks in /Users/nekrich/Developer/
setapp-desktop/DerivedData/SetappDesktop/Build/Products/Debug/Setapp.app/Contents/
Library/QuickLook/SetappQL.qlgenerator/Contents/Frameworks/SetappInterface.framework/
Versions/A/Frameworks/CocoaLumberjack.framework/Versions/A/CocoaLumberjack 

being ignored in restricted program because of @executable_path 
(Codesign main executable with Library Validation to allow @ paths)
```

Since CocoaLumberjack uses no frameworks, it was worth a try to remove `LD_RUNPATH_SEARCH_PATHS`    

and IT WORKED 🎉
